### PR TITLE
Add translation and transcript storage API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+transcripts/

--- a/index.html
+++ b/index.html
@@ -270,8 +270,18 @@
         return;
       }
 
-      const combinedTranscript = window.interviewTranscript.map((pair,index)=>
-        `Q${index +1}: ${pair.question}\nA${index + 1}: ${pair.answer}`
+      // translate transcript to English on the server
+      const translateRes = await fetch("http://localhost:8000/translate-transcript", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transcript: window.interviewTranscript })
+      });
+
+      const translated = await translateRes.json();
+      const processedTranscript = translated.transcript || window.interviewTranscript;
+
+      const combinedTranscript = processedTranscript.map((pair, index) =>
+        `Q${index + 1}: ${pair.question}\nA${index + 1}: ${pair.answer}`
       ).join('\n\n');
 
       const prompt = `
@@ -304,6 +314,13 @@
       const feedbackEl = document.createElement('div');
       feedbackEl.innerHTML = `<h3> Interview feedback </h3><p>${markdownHTML}</p>`;
       document.getElementById('output').appendChild(feedbackEl);
+
+      // persist transcript on the server
+      await fetch("http://localhost:8000/save-transcript", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transcript: window.interviewTranscript })
+      });
     }
 
   </script>

--- a/main.py
+++ b/main.py
@@ -3,6 +3,11 @@ from fastapi.middleware.cors import CORSMiddleware
 import httpx
 import os
 import ssl
+import json
+import datetime
+from pathlib import Path
+from langdetect import detect
+from googletrans import Translator
 
 app = FastAPI()
 
@@ -18,6 +23,11 @@ app.add_middleware(
 # Set your Gemini API Key and model
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "AIzaSyB3HLb0TmvqHCoovYqYaSq0fJvHARn9FXk")
 # GEMINI_MODEL = "gemini-1.5-pro"  # ✅ FIXED model name
+
+TRANSCRIPT_DIR = Path("transcripts")
+TRANSCRIPT_DIR.mkdir(exist_ok=True)
+
+translator = Translator()
 
 @app.post("/generate-feedback")
 async def generate_feedback(request: Request):
@@ -59,3 +69,46 @@ async def generate_feedback(request: Request):
     except Exception as e:
         print("🔴 Top-level Exception occurred:", str(e))
         return {"error": str(e)}
+
+
+@app.post("/save-transcript")
+async def save_transcript(request: Request):
+    data = await request.json()
+    transcript = data.get("transcript")
+    if not isinstance(transcript, list):
+        return {"error": "Invalid transcript"}
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    file_path = TRANSCRIPT_DIR / f"transcript_{timestamp}.json"
+    with open(file_path, "w") as f:
+        json.dump(transcript, f, indent=2)
+    return {"status": "saved"}
+
+
+@app.post("/translate-transcript")
+async def translate_transcript(request: Request):
+    data = await request.json()
+    transcript = data.get("transcript", [])
+    if not isinstance(transcript, list):
+        return {"error": "Invalid transcript"}
+
+    processed = []
+    for pair in transcript:
+        question = pair.get("question", "")
+        answer = pair.get("answer", "")
+
+        try:
+            if question and detect(question) != "en":
+                question = translator.translate(question, dest="en").text
+        except Exception:
+            pass
+
+        try:
+            if answer and detect(answer) != "en":
+                answer = translator.translate(answer, dest="en").text
+        except Exception:
+            pass
+
+        processed.append({"question": question, "answer": answer})
+
+    return {"transcript": processed}


### PR DESCRIPTION
## Summary
- save transcripts on the server
- translate transcript segments to English server-side
- call new APIs from the browser
- ignore transcripts folder

## Testing
- `python -m py_compile main.py` *(fails: Could not install langdetect & googletrans)*

------
https://chatgpt.com/codex/tasks/task_e_6874ce0541788330ac377bcf6c23e187